### PR TITLE
Replace busser_* commands with busser.* as changed in kitchen 1.3

### DIFF
--- a/lib/kitchen/driver/vagrant_winrm.rb
+++ b/lib/kitchen/driver/vagrant_winrm.rb
@@ -65,13 +65,13 @@ module Kitchen
 
       def setup(state)
         create_vagrantfile
-        run_remote busser_setup_cmd
+        run_remote busser.setup_cmd
       end
 
       def verify(state)
         create_vagrantfile
-        run_remote busser_sync_cmd
-        run_remote busser_run_cmd
+        run_remote busser.sync_cmd
+        run_remote busser.run_cmd
       end
 
       def destroy(state)


### PR DESCRIPTION
test-kitchen/test-kitchen@032ada6a36532c07a5ed2190ca9449afd58ca728 removed these methods and suggests a non-deprecated way to use them.
