### PR TITLE
Use shellescape to properly escape shell commands

### DIFF
--- a/lib/kitchen/driver/vagrant_winrm.rb
+++ b/lib/kitchen/driver/vagrant_winrm.rb
@@ -2,6 +2,7 @@ require 'fileutils'
 require 'rubygems/version'
 require 'kitchen'
 require 'tempfile'
+require 'shellwords'
 
 module Kitchen
 
@@ -108,7 +109,7 @@ module Kitchen
         return unless cmd
 
         debug("Executing winRM command #{cmd}")
-        run "vagrant winrm -c \"#{cmd.gsub(/["`\\\x0]/, '\\\\\0')}\""
+        run "vagrant winrm -c #{cmd.shellescape}"
       end
 
       def run(cmd, options = {})


### PR DESCRIPTION
Powershell commands appear to be getting mangled when setting $env:SOMETHING, as the '$env' is getting replaced by the local shell. (Pretty much anything with a `$` is likely to have the same problem.)

On my system, this causes busser (and therefore serverspec) to explode when setting commands such as `$env:BUSSER_ROOT="c:/tmp/busser"` (which becomes `:BUSSER_ROOT="c:/tmp/busser"`)

This patch more correctly escapes the shell command passed to `vagrant winrm`
